### PR TITLE
Allow compilation with mariadb-connector-c

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -58,6 +58,17 @@ static ID intern_brackets, intern_merge, intern_merge_bang, intern_new_with_args
 #endif
 
 /*
+ * mariadb-connector-c defines CLIENT_SESSION_TRACKING and SESSION_TRACK_TRANSACTION_TYPE
+ * while mysql-connector-c defines CLIENT_SESSION_TRACK and SESSION_TRACK_TRANSACTION_STATE
+ * This is a hack to take care of both clients.
+ */
+#if defined(CLIENT_SESSION_TRACK)
+#elif defined(CLIENT_SESSION_TRACKING)
+  #define CLIENT_SESSION_TRACK CLIENT_SESSION_TRACKING
+  #define SESSION_TRACK_TRANSACTION_STATE SESSION_TRACK_TRANSACTION_TYPE
+#endif
+
+/*
  * compatibility with mysql-connector-c 6.1.x, and with MySQL 5.7.3 - 5.7.10.
  */
 #ifdef HAVE_CONST_MYSQL_OPT_SSL_ENFORCE


### PR DESCRIPTION
In the original [PR](https://github.com/brianmario/mysql2/pull/1092) where we introduce session_tracking on mysql2 gem, we used the constant CLIENT_SESSION_TRACK.

I found out that mariadb-connector-c uses [CLIENT_SESSION_TRACKING](https://github.com/mariadb-corporation/mariadb-connector-c/blob/3ffa60dbea57c69926f3cfce286e9f650e3c0047/include/mariadb_com.h#L162) instead and therefore the mysql2 gem wouldn't work.
mariadb also defines an enum value [SESSION_TRACK_TRANSACTION_TYPE](https://github.com/mariadb-corporation/mariadb-connector-c/blob/3ffa60dbea57c69926f3cfce286e9f650e3c0047/include/mariadb_com.h#L310) instead of mysql's [SESSION_TRACK_TRANSACTION_STATE](https://dev.mysql.com/doc/refman/5.7/en/session-state-tracking.html).

In our codebase, we use mariadb-connector-c on dev while mysql-connector-c on ci and production. To make it work on all, we need this patch.
