### PR TITLE
Fix for last argument warning

### DIFF
--- a/lib/mysql2/error.rb
+++ b/lib/mysql2/error.rb
@@ -52,7 +52,7 @@ module Mysql2
     def initialize(msg, server_version = nil, error_number = nil, sql_state = nil)
       @server_version = server_version
       @error_number = error_number
-      @sql_state = sql_state ? sql_state.encode(ENCODE_OPTS) : nil
+      @sql_state = sql_state ? sql_state.encode(**ENCODE_OPTS) : nil
 
       super(clean_message(msg))
     end
@@ -91,9 +91,9 @@ module Mysql2
     # Returns a valid UTF-8 string.
     def clean_message(message)
       if @server_version && @server_version > 50500
-        message.encode(ENCODE_OPTS)
+        message.encode(**ENCODE_OPTS)
       else
-        message.encode(Encoding::UTF_8, ENCODE_OPTS)
+        message.encode(Encoding::UTF_8, **ENCODE_OPTS)
       end
     end
   end


### PR DESCRIPTION
Fix for `warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call`.

The master branch has [already been updated](https://github.com/Shopify/mysql2/commit/fee3c71dd1d8c91d9e0b89ee08b8673f4666cf64) to fix this warning message.

It seems like the quickest fix is to just update the relevant lines for this branch which is currently used by https://github.com/Shopify/storefront-renderer, instead of rebasing on master and dealing with the conflicts. 

